### PR TITLE
커스텀 예외 만들고 swagger 에 적용하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -44,7 +43,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	implementation 'io.swagger.core.v3:swagger-annotations:2.2.30'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 	testImplementation 'io.projectreactor:reactor-test'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'com.h2database:h2'

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
@@ -29,7 +29,6 @@ public class KakaoAuthController {
         KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(accessToken);
         Long kakaoId = userInfo.getId();
         KakaoAuthResponseDto response = memberService.getMemberStatus(kakaoId);
-        System.out.println("response = " + response);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/MemberController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.controller;
 
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupRequestDto;
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.entity.Member;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.service.MemberService;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.member.SignUpDocs;
@@ -18,12 +19,8 @@ public class MemberController {
 
     @PostMapping("/signup")
     @SignUpDocs
-    public ResponseEntity<Member> signup(@RequestBody SignupRequestDto dto) {
-        try {
-            Member savedMember = memberService.signup(dto);
-            return ResponseEntity.ok(savedMember);
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-        }
+    public ResponseEntity<SignupResponseDto> signup(@RequestBody SignupRequestDto dto) {
+        SignupResponseDto response = memberService.signup(dto);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/MemberController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.Signup
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.entity.Member;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.service.MemberService;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.member.SignUpDocs;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,7 @@ public class MemberController {
 
     @PostMapping("/signup")
     @SignUpDocs
-    public ResponseEntity<SignupResponseDto> signup(@RequestBody SignupRequestDto dto) {
+    public ResponseEntity<SignupResponseDto> signup(@Valid @RequestBody SignupRequestDto dto) {
         SignupResponseDto response = memberService.signup(dto);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/dto/SignupRequestDto.java
@@ -1,12 +1,29 @@
 package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
+@Builder
 public class SignupRequestDto {
-    private Long kakaoId;   // kakao에서 받아온 ID
+    @NotNull(message = "kakaoId는 필수입니다.")
+    private Long kakaoId;
+
+    @NotBlank(message = "이름은 필수입니다.")
     private String name;
+
+    @NotBlank(message = "위치는 필수입니다.")
     private String location;
-    private String role;    // CONSUMER 또는 CORPORATE
+
+    @NotBlank(message = "역할은 필수입니다.")
+    @Pattern(regexp = "CONSUMER|CORPORATE", message = "role은 CONSUMER 또는 CORPORATE만 가능합니다.")
+    private String role;
+
+    // TODO : 카카오 프로필은 사용하지 않음. 기본 프로필 중에 어떤 것을 선택했는지를 담으면 될 거 같음.
     private String profileImageUrl;
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/dto/SignupResponseDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/dto/SignupResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SignupResponseDto {
+    private final Long memberId;
+
+    private SignupResponseDto(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public static SignupResponseDto from(Long memberId) {
+        return new SignupResponseDto(memberId);
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/KakaoServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/KakaoServiceImpl.java
@@ -2,6 +2,8 @@ package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.service;
 
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.KakaoTokenResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.KakaoUserInfoResponseDto;
+import com.example.seoulpublicdata2025backend.global.exception.customException.KakaoApiException;
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,8 +43,10 @@ public class KakaoServiceImpl implements KakaoService{
                         .build(true))
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
                 .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
-                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .onStatus(HttpStatusCode::is4xxClientError,
+                        clientResponse -> Mono.error(new KakaoApiException(ErrorCode.INVALID_KAKAO_REQUEST)))
+                .onStatus(HttpStatusCode::is5xxServerError,
+                        clientResponse -> Mono.error(new KakaoApiException(ErrorCode.KAKAO_SERVER_ERROR)))
                 .bodyToMono(KakaoTokenResponseDto.class)
                 .block();
 
@@ -66,8 +70,10 @@ public class KakaoServiceImpl implements KakaoService{
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
                 .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
-                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .onStatus(HttpStatusCode::is4xxClientError,
+                        clientResponse -> Mono.error(new KakaoApiException(ErrorCode.INVALID_KAKAO_REQUEST)))
+                .onStatus(HttpStatusCode::is5xxServerError,
+                        clientResponse -> Mono.error(new KakaoApiException(ErrorCode.KAKAO_SERVER_ERROR)))
                 .bodyToMono(KakaoUserInfoResponseDto.class)
                 .block();
 

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberService.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberService.java
@@ -2,6 +2,7 @@ package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.service;
 
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.KakaoAuthResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupRequestDto;
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.entity.Member;
 
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.type.MemberStatus;
@@ -9,7 +10,7 @@ import java.util.Optional;
 
 public interface MemberService {
 
-    Member signup(SignupRequestDto dto);
+    SignupResponseDto signup(SignupRequestDto dto);
 
     Optional<Member> findByKakaoId(Long kakaoId);
 

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceImpl.java
@@ -3,9 +3,13 @@ package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.service;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dao.MemberRepository;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.KakaoAuthResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupRequestDto;
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.entity.Member;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.type.MemberStatus;
+import com.example.seoulpublicdata2025backend.global.exception.customException.AuthenticationException;
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -17,8 +21,14 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
 
     @Override
-    public Member signup(SignupRequestDto dto) {
-        return memberRepository.save(Member.create(dto));
+    public SignupResponseDto signup(SignupRequestDto dto) {
+        Member member = Member.create(dto);
+        try {
+            Member savedMember = memberRepository.save(member);
+            return SignupResponseDto.from(savedMember.getKakaoId());
+        } catch (DataIntegrityViolationException exception) {
+            throw new AuthenticationException(ErrorCode.DUPLICATE_MEMBER);
+        }
     }
 
     @Override

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceImpl.java
@@ -6,7 +6,7 @@ import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.Signup
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.entity.Member;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.type.MemberStatus;
-import com.example.seoulpublicdata2025backend.global.exception.customException.AuthenticationException;
+import com.example.seoulpublicdata2025backend.global.exception.customException.DuplicationMemberException;
 import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -27,7 +27,7 @@ public class MemberServiceImpl implements MemberService {
             Member savedMember = memberRepository.save(member);
             return SignupResponseDto.from(savedMember.getKakaoId());
         } catch (DataIntegrityViolationException exception) {
-            throw new AuthenticationException(ErrorCode.DUPLICATE_MEMBER);
+            throw new DuplicationMemberException(ErrorCode.DUPLICATE_MEMBER);
         }
     }
 

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/type/MemberStatus.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/type/MemberStatus.java
@@ -1,7 +1,5 @@
 package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.type;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public enum MemberStatus {
     MEMBER("회원"),
     NOT_MEMBER("비회원");

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/ErrorResponse.java
@@ -1,20 +1,88 @@
 package com.example.seoulpublicdata2025backend.global.exception;
 
 import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
-    private Integer httpStatus;
-    private String code;
-    private String message;
 
-    public ErrorResponse(ErrorCode errorCode) {
-        this.httpStatus = errorCode.getHttpStatus().value();
-        this.code = errorCode.getCode();
-        this.message = errorCode.getMessage();
+    private String message;
+    private Integer status;
+    private List<FieldError> errors;
+    private String code;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime time;
+
+    private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+        this.message = code.getMessage();
+        this.status = code.getHttpStatus().value();
+        this.errors = errors;
+        this.code = code.getCode();
+        this.time = LocalDateTime.now();
     }
+
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.status = code.getHttpStatus().value();
+        this.code = code.getCode();
+        this.errors = new ArrayList<>();
+    }
+
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        final String value = e.getValue() == null ? "" : e.getValue().toString();
+        final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of(e.getName(), value, e.getErrorCode());
+        return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+    }
+
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        private FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(final String field, final String value, final String reason) {
+            List<FieldError> fieldErrors = new ArrayList<>();
+            fieldErrors.add(new FieldError(field, value, reason));
+            return fieldErrors;
+        }
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.example.seoulpublicdata2025backend.global.exception;
+
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor
+public class ErrorResponse {
+    private HttpStatus httpStatus;
+    private String code;
+    private String message;
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.httpStatus = errorCode.getHttpStatus();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/ErrorResponse.java
@@ -8,12 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @NoArgsConstructor
 public class ErrorResponse {
-    private HttpStatus httpStatus;
+    private Integer httpStatus;
     private String code;
     private String message;
 
     public ErrorResponse(ErrorCode errorCode) {
-        this.httpStatus = errorCode.getHttpStatus();
+        this.httpStatus = errorCode.getHttpStatus().value();
         this.code = errorCode.getCode();
         this.message = errorCode.getMessage();
     }

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/GlobalExceptionHandler.java
@@ -2,18 +2,24 @@ package com.example.seoulpublicdata2025backend.global.exception;
 
 import com.example.seoulpublicdata2025backend.global.exception.customException.CustomException;
 import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
-        ErrorCode errorCode = ex.getErrorCode();
-        ErrorResponse errorResponse = new ErrorResponse(errorCode);
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("CustomException", e);
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(errorResponse);
@@ -21,17 +27,40 @@ public class GlobalExceptionHandler {
 
     // @Valid 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException exception) {
-        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE);
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
                 .body(errorResponse);
     }
 
+    /**
+     * enum type 일치하지 않아 binding 못할 경우 발생
+     * 주로 @RequestParam enum으로 binding 못했을 경우 발생
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        final ErrorResponse response = ErrorResponse.of(e);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 지원하지 않은 HTTP method 호출 할 경우 발생
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
     // 기타 예외
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
-        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Exception", e);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                 .body(errorResponse);

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/GlobalExceptionHandler.java
@@ -21,7 +21,7 @@ public class GlobalExceptionHandler {
 
     // @Valid 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationException() {
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException exception) {
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE);
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
@@ -30,7 +30,7 @@ public class GlobalExceptionHandler {
 
     // 기타 예외
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException() {
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.example.seoulpublicdata2025backend.global.exception;
+
+import com.example.seoulpublicdata2025backend.global.exception.customException.CustomException;
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        ErrorResponse errorResponse = new ErrorResponse(errorCode);
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponse);
+    }
+
+    // @Valid 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException() {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
+                .body(errorResponse);
+    }
+
+    // 기타 예외
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException() {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(errorResponse);
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/AuthenticationException.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/AuthenticationException.java
@@ -2,8 +2,8 @@ package com.example.seoulpublicdata2025backend.global.exception.customException;
 
 import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
 
-public class KakaoApiException extends AuthenticationException {
-    public KakaoApiException(ErrorCode errorCode) {
+public class AuthenticationException extends CustomException{
+    public AuthenticationException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/CustomException.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/CustomException.java
@@ -1,0 +1,14 @@
+package com.example.seoulpublicdata2025backend.global.exception.customException;
+
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/DuplicationMemberException.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/DuplicationMemberException.java
@@ -1,0 +1,9 @@
+package com.example.seoulpublicdata2025backend.global.exception.customException;
+
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+
+public class DuplicationMemberException extends AuthenticationException{
+    public DuplicationMemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/KakaoApiException.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/KakaoApiException.java
@@ -1,0 +1,10 @@
+package com.example.seoulpublicdata2025backend.global.exception.customException;
+
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+
+public class KakaoApiException extends CustomException {
+
+    public KakaoApiException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
@@ -1,0 +1,36 @@
+package com.example.seoulpublicdata2025backend.global.exception.errorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 1000번대: 인증 관련
+    INVALID_CODE("1000", "유효하지 않은 인가코드입니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("1001", "인증되지 않은 요청입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_KAKAO_REQUEST("1002", "카카오 인가 요청이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+    KAKAO_SERVER_ERROR("1003", "카카오 서버에 문제가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // 2000번대: 입력값 검증 실패
+    INVALID_INPUT_VALUE("2000", "입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    TYPE_MISMATCH("2001", "요청 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_ENUM_VALUE("2002", "역할 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+
+    // 3000번대: 회원 관련
+    DUPLICATE_MEMBER("3000", "이미 가입된 사용자입니다.", HttpStatus.BAD_REQUEST),
+    USER_NOT_FOUND("3001", "사용자를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+    // 4000번대: 권한 관련
+    FORBIDDEN("4000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+    // 5000번대: 서버 오류
+    INTERNAL_SERVER_ERROR("5000", "서버에 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_IMAGE_URL("5001", "프로필 이미지 URL이 유효하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
@@ -16,8 +16,8 @@ public enum ErrorCode {
 
     // 2000번대: 입력값 검증 실패
     INVALID_INPUT_VALUE("2000", "입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
-    TYPE_MISMATCH("2001", "요청 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
-    INVALID_ENUM_VALUE("2002", "역할 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_TYPE_VALUE("2001", "요청 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    METHOD_NOT_ALLOWED("2003", "허용되지 않은 HTTP 메서드입니다", HttpStatus.BAD_REQUEST),
 
     // 3000번대: 회원 관련
     DUPLICATE_MEMBER("3000", "이미 가입된 사용자입니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
@@ -20,8 +20,8 @@ public enum ErrorCode {
     INVALID_ENUM_VALUE("2002", "역할 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 3000번대: 회원 관련
-    DUPLICATE_MEMBER("3000", "이미 가입된 사용자입니다.", HttpStatus.BAD_REQUEST),
-    USER_NOT_FOUND("3001", "사용자를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATE_MEMBER("3000", "이미 가입된 사용자입니다.", HttpStatus.CONFLICT),
+    USER_NOT_FOUND("3001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 4000번대: 권한 관련
     FORBIDDEN("4000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/KakaoLoginCheckDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/KakaoLoginCheckDocs.java
@@ -49,5 +49,41 @@ import java.lang.annotation.Target;
 
         )
 )
+@ApiResponse(
+        responseCode = "400",
+        description = "클라이언트의 카카오 요청이 유효하지 않을 경우",
+        content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                        name = "INVALID_KAKAO_REQUEST",
+                        description = "인가 코드가 잘못되었거나 만료된 경우",
+                        value = """
+                                {
+                                  "httpStatus": 400,
+                                  "code": "1002",
+                                  "message": "카카오 요청이 유효하지 않습니다."
+                                }
+                                """
+                )
+        )
+)
+@ApiResponse(
+        responseCode = "500",
+        description = "카카오 서버와 통신 중 에러가 발생한 경우",
+        content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                        name = "KAKAO_SERVER_ERROR",
+                        description = "카카오 서버 장애, 응답 오류 등",
+                        value = """
+                                {
+                                  "httpStatus": 500,
+                                  "code": "1003",
+                                  "message": "카카오 서버 오류입니다."
+                                }
+                                """
+                )
+        )
+)
 public @interface KakaoLoginCheckDocs {
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/KakaoLoginCheckDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/KakaoLoginCheckDocs.java
@@ -59,10 +59,12 @@ import java.lang.annotation.Target;
                         description = "인가 코드가 잘못되었거나 만료된 경우",
                         value = """
                                 {
-                                  "httpStatus": 400,
-                                  "code": "1002",
-                                  "message": "카카오 요청이 유효하지 않습니다."
-                                }
+                                   "status": 400,
+                                   "code": "INVALID_KAKAO_REQUEST",
+                                   "message": "카카오 요청이 유효하지 않습니다.",
+                                   "errors": []
+                                   "time": "2025-04-15T10:12:34"
+                                 }
                                 """
                 )
         )
@@ -77,9 +79,11 @@ import java.lang.annotation.Target;
                         description = "카카오 서버 장애, 응답 오류 등",
                         value = """
                                 {
-                                  "httpStatus": 500,
-                                  "code": "1003",
-                                  "message": "카카오 서버 오류입니다."
+                                   "status": 500,
+                                   "code": "KAKAO_SERVER_ERROR",
+                                   "message": "카카오 서버 오류입니다.",
+                                   "errors": []
+                                   "time": "2025-04-15T10:12:34"
                                 }
                                 """
                 )

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
@@ -38,14 +38,14 @@ import java.lang.annotation.Target;
                         name = "회원가입 요청 예시",
                         description = "성공적인 회원가입 요청 예시",
                         value = """
-                {
-                  "kakaoId": 123456789,
-                  "name": "홍길동",
-                  "location": "서울특별시 강남구",
-                  "role": "CONSUMER",
-                  "profileImageUrl": "https://k.kakaocdn.net/dn/example-profile.png"
-                }
-                """
+                                {
+                                  "kakaoId": 123456789,
+                                  "name": "홍길동",
+                                  "location": "서울특별시 강남구",
+                                  "role": "CONSUMER",
+                                  "profileImageUrl": "https://k.kakaocdn.net/dn/example-profile.png"
+                                }
+                                """
                 )
         )
 )

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
@@ -78,9 +78,22 @@ import java.lang.annotation.Target;
                         description = "입력 값 중 null 값이 있는 경우",
                         value = """
                                 {
-                                  "httpStatus": 400,
-                                  "code": "2000",
-                                  "message": "입력값이 올바르지 않습니다."
+                                  "status": 400,
+                                  "code": "INVALID_INPUT_VALUE",
+                                  "message": "입력값이 올바르지 않습니다.",
+                                  "errors": [
+                                    {
+                                      "field": "name",
+                                      "value": "",
+                                      "reason": "이름은 필수입니다."
+                                    },
+                                    {
+                                      "field": "location",
+                                      "value": "",
+                                      "reason": "위치는 필수입니다."
+                                    }
+                                  ],
+                                  "time": "2025-04-15T10:12:34"
                                 }
                                 """
                 )
@@ -96,9 +109,11 @@ import java.lang.annotation.Target;
                         description = "이미 존재하는 카카오 ID로 가입을 시도했을 때",
                         value = """
                                 {
-                                  "httpStatus": 409,
-                                  "code": "3000",
-                                  "message": "이미 존재하는 회원입니다."
+                                  "status": 409,
+                                  "code": "DUPLICATE_MEMBER",
+                                  "message": "이미 존재하는 회원입니다.",
+                                  "errors": [],
+                                  "time": "2025-04-15T10:12:34"
                                 }
                                 """
                 )
@@ -114,14 +129,17 @@ import java.lang.annotation.Target;
                         description = "서버 오류로 인해 회원가입에 실패한 경우",
                         value = """
                                 {
-                                  "httpStatus": 500,
-                                  "code": "5000",
-                                  "message": "서버에 문제가 발생했습니다. 관리자에게 문의하세요."
+                                  "status": 500,
+                                  "code": "INTERNAL_SERVER_ERROR",
+                                  "message": "서버에 문제가 발생했습니다. 관리자에게 문의하세요.",
+                                  "errors": [],
+                                  "time": "2025-04-15T10:12:34"
                                 }
                                 """
                 )
         )
 )
+
 
 public @interface SignUpDocs {
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
@@ -2,6 +2,7 @@ package com.example.seoulpublicdata2025backend.global.swagger.annotations.member
 
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.KakaoAuthResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupRequestDto;
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -51,7 +52,39 @@ import java.lang.annotation.Target;
 )
 @ApiResponse(
         responseCode = "200",
-        description = "회원가입에 성공, 반환 타입은 추후 결정하여 올리겠습니다."
+        description = "회원가입에 성공",
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = SignupResponseDto.class),
+                examples = @ExampleObject(
+                                name = "회원가입 성공 예시",
+                                description = "성공한 회원가입 응답 예시",
+                                value = """
+                                {
+                                    "memberId": 1
+                                }
+                                """
+                        )
+
+        )
+)
+@ApiResponse(
+        responseCode = "400",
+        description = "요청 데이터가 유효하지 않음 (입력값이 null인 경우)",
+        content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                        name = "회원가입 실패 예시",
+                        description = "입력 값 중 null 값이 있는 경우",
+                        value = """
+                                {
+                                  "httpStatus": 400,
+                                  "code": "2000",
+                                  "message": "입력값이 올바르지 않습니다."
+                                }
+                                """
+                )
+        )
 )
 public @interface SignUpDocs {
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
@@ -70,7 +70,7 @@ import java.lang.annotation.Target;
 )
 @ApiResponse(
         responseCode = "400",
-        description = "요청 데이터가 유효하지 않음 (입력값이 null인 경우)",
+        description = "요청 데이터가 유효하지 않음 (입력값 중에 null 값이 있는 경우)",
         content = @Content(
                 mediaType = "application/json",
                 examples = @ExampleObject(
@@ -86,5 +86,42 @@ import java.lang.annotation.Target;
                 )
         )
 )
+@ApiResponse(
+        responseCode = "409",
+        description = "이미 가입된 회원",
+        content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                        name = "회원가입 실패 - 중복 회원",
+                        description = "이미 존재하는 카카오 ID로 가입을 시도했을 때",
+                        value = """
+                                {
+                                  "httpStatus": 409,
+                                  "code": "3000",
+                                  "message": "이미 존재하는 회원입니다."
+                                }
+                                """
+                )
+        )
+)
+@ApiResponse(
+        responseCode = "500",
+        description = "서버 내부 에러",
+        content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                        name = "회원가입 실패 - 서버 오류",
+                        description = "서버 오류로 인해 회원가입에 실패한 경우",
+                        value = """
+                                {
+                                  "httpStatus": 500,
+                                  "code": "5000",
+                                  "message": "서버에 문제가 발생했습니다. 관리자에게 문의하세요."
+                                }
+                                """
+                )
+        )
+)
+
 public @interface SignUpDocs {
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,15 +1,14 @@
-???? DB (H2 ??? DB)
 spring.datasource.url=jdbc:h2:mem:testdb;
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=.
 
-# JPA ??
+
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 
 jwt.secret=4d3fa7c9b38f4ff4bfa9a67c827293ee5eb7db918d570b93a3be0de19e098187
-# 2?? (ms ??)
+
 jwt.expireDate.accessToken=7200000
-# 30?
+
 jwt.expireDate.refreshToken=2592000000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,13 +6,10 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-# ??? ???? ?? ????
 kakao.auth.client=66c13241398206c8f4c957807de769c2
 kakao.auth.redirect=http://localhost:8080/auth/login/kakao
 
 # JWT
 jwt.secret=${JWT_SECRET}
-# 2?? (ms ??)
 jwt.expireDate.accessToken=7200000
-# 30?
 jwt.expireDate.refreshToken=2592000000

--- a/src/test/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceTest.java
+++ b/src/test/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceTest.java
@@ -1,44 +1,50 @@
 package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dao.MemberRepository;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupRequestDto;
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.entity.Member;
-import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-@SpringBootTest
-@TestPropertySource(properties = "JWT_SECRET=4d3fa7c9b38f4ff4bfa9a67c827293ee5eb7db918d570b93a3be0de19e098187")
-@Transactional
+@ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
-    @Autowired
-    MemberService memberService;
+    @InjectMocks
+    MemberServiceImpl memberService;
 
-    @Autowired
+    @Mock
     MemberRepository memberRepository;
 
     @Test
+    @DisplayName("회원가입 성공")
     void join() {
         // given
-        SignupRequestDto dto = new SignupRequestDto();
-        ReflectionTestUtils.setField(dto, "kakaoId", 123456L);
-        ReflectionTestUtils.setField(dto, "name", "루페온");
-        ReflectionTestUtils.setField(dto, "location", "서울");
-        ReflectionTestUtils.setField(dto, "role", "CONSUMER");
-        ReflectionTestUtils.setField(dto, "profileImageUrl", "http://example.com/image.png");
+        SignupRequestDto requestDto = SignupRequestDto.builder()
+                .kakaoId(123456L)
+                .name("루페온")
+                .location("서울")
+                .role("CONSUMER")
+                .profileImageUrl("http://example.com/image.png")
+                .build();
+
+        Member member = Member.create(requestDto);
+
+        when(memberRepository.save(any(Member.class))).thenReturn(member);
 
         // when
-        memberService.signup(dto);
+        SignupResponseDto response = memberService.signup(requestDto);
 
-        // join
-        Member saved = memberRepository.findByKakaoId(123456L).orElseThrow();
-        assertEquals("루페온", saved.getName());
+        // then
+        assertEquals(123456L, response.getMemberId());
     }
 
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #21 

## 📌 작업 내용 및 특이사항
- `CustomException`를 만들고 `GlobalExceptionHandler`를 구현하여 예외를 처리합니다.
- swagger 에 기본적인 예외에 대한 반환 응답을 제시하였습니다.
- `CustomExcepion`을 제일 조상으로 하고, 예외 타입에 따라 새로운 예외를 만들고 `CustomExcepion` 을 상속받게 했습니다. (지금은 인증 관련 로직만 존재하기 때문에 `AuthenticationException` 만 두었고, 이것들을 상속받은 2개의 예외를 구성했습니다.
- 이해를 돕기 위해 간단한 그림을 제시합니다.
<img src="https://github.com/user-attachments/assets/75a6a51a-cf6e-4f70-8169-26aacb469600" width="400"/>

## 📝 참고사항
- 앞으로도 필요한 예외를 만들 때 `CustomException` 예외를 상속하여 만들고 그 예외가 크게 어떤 클래스에 대한 예외인지 만들고, 세부적인 예외를 만들면 됩니다.
- **ErrorResponse 에 포함되면 좋을 거 같은 정보를 추가로 제시해주시면 좋겠습니다. 현재로써는 3가지 정보만 제시한 상태입니다.**
- code의 경우 저희가 임의로 정한 에러 코드입니다 (카카오에서도 있길래 구현을 해보았음). **저희가 에러 코드와 원인을 제시한 표를 만들어 둔다면 클라이언트 측에서도 에러에 대한 원인을 알 수 있게 하는 의도입니다만... 꼭 필요한지는 의견을 부탁드립니다.**

## 📚 기타
-
