### PR TITLE
[Feat] CORS 설정 추가

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/WebConfig.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.example.seoulpublicdata2025backend.global.auth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    // URL 확인 후에 수정할 수 있음
+    private static final String LOCAL_REACT_CLIENT_URL = "http://localhost:3000";
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(LOCAL_REACT_CLIENT_URL)
+                .allowedMethods("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #29 

## 📌 작업 내용 및 특이사항
- 프론트가 서버에 요청을 하기 위해서는 CORS 세팅을 해줘야 합니다.
- React를 사용하면 기본 포트번호가 3000 이라고 해서 다음과 같이 세팅했고, 추후 변경해야 된다면 바로 변경하면 됩니다.

## 📝 참고사항
- 

## 📚 기타
-
