### PR TITLE
[Feat] AWS S3 presigned url 발급 로직

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation "io.awspring.cloud:spring-cloud-aws-starter:3.3.0"
+	implementation "software.amazon.awssdk:s3:2.31.25"
 
 	testImplementation 'io.projectreactor:reactor-test'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/Service/AwsService.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/Service/AwsService.java
@@ -1,0 +1,9 @@
+package com.example.seoulpublicdata2025backend.domain.aws.Service;
+
+import com.example.seoulpublicdata2025backend.domain.aws.dto.PresignedUrlRequestDto;
+
+public interface AwsService {
+    String generateGetPreSignedUrl(String objectKey);
+
+    String generatePutPreSignedUrl(PresignedUrlRequestDto dto);
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/Service/AwsService.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/Service/AwsService.java
@@ -1,9 +1,10 @@
 package com.example.seoulpublicdata2025backend.domain.aws.Service;
 
 import com.example.seoulpublicdata2025backend.domain.aws.dto.PresignedUrlRequestDto;
+import com.example.seoulpublicdata2025backend.domain.aws.dto.PresignedUrlResponseDto;
 
 public interface AwsService {
     String generateGetPreSignedUrl(String objectKey);
 
-    String generatePutPreSignedUrl(PresignedUrlRequestDto dto);
+    PresignedUrlResponseDto generatePutPreSignedUrl(PresignedUrlRequestDto dto);
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/Service/AwsServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/Service/AwsServiceImpl.java
@@ -1,0 +1,75 @@
+package com.example.seoulpublicdata2025backend.domain.aws.Service;
+
+import com.example.seoulpublicdata2025backend.domain.aws.dto.PresignedUrlRequestDto;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class AwsServiceImpl implements AwsService {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Override
+    public String generatePutPreSignedUrl(PresignedUrlRequestDto dto) {
+        String objectKey = createObjectKey(dto);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(objectKey)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(builder -> builder
+                .putObjectRequest(putObjectRequest)
+                .signatureDuration(Duration.ofMinutes(10))
+        );
+
+        return presignedRequest.url().toString();
+    }
+
+    @Override
+    public String generateGetPreSignedUrl(String objectKey) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(objectKey)
+                .build();
+
+        PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner.presignGetObject(builder -> builder
+                .getObjectRequest(getObjectRequest)
+                .signatureDuration(Duration.ofMinutes(10))
+        );
+
+        return presignedGetObjectRequest.url().toString();
+    }
+
+    private String createObjectKey(PresignedUrlRequestDto dto) {
+        String originalFileName = dto.getOriginalFileName();
+        String ext = originalFileName.substring(originalFileName.lastIndexOf('.') + 1);
+        String uuid = UUID.randomUUID().toString();
+        LocalDate today = LocalDate.now();
+
+        String prefix = switch (dto.getType()) {
+            case REVIEW -> "reviews";
+            case ETC -> "etc";
+        };
+
+        return String.format("%s/user-%d/%d/%02d/%02d/%s.%s",
+                prefix, dto.getKakaoId(),
+                today.getYear(), today.getMonthValue(), today.getDayOfMonth(),
+                uuid, ext
+        );
+    }
+
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/Service/AwsServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/Service/AwsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.seoulpublicdata2025backend.domain.aws.Service;
 
 import com.example.seoulpublicdata2025backend.domain.aws.dto.PresignedUrlRequestDto;
+import com.example.seoulpublicdata2025backend.domain.aws.dto.PresignedUrlResponseDto;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -23,7 +24,7 @@ public class AwsServiceImpl implements AwsService {
     private String bucketName;
 
     @Override
-    public String generatePutPreSignedUrl(PresignedUrlRequestDto dto) {
+    public PresignedUrlResponseDto generatePutPreSignedUrl(PresignedUrlRequestDto dto) {
         String objectKey = createObjectKey(dto);
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -36,7 +37,10 @@ public class AwsServiceImpl implements AwsService {
                 .signatureDuration(Duration.ofMinutes(10))
         );
 
-        return presignedRequest.url().toString();
+        return PresignedUrlResponseDto.builder()
+                .presignedUrl(presignedRequest.url().toString())
+                .key(objectKey)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/config/AwsConfig.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/config/AwsConfig.java
@@ -1,0 +1,33 @@
+package com.example.seoulpublicdata2025backend.domain.aws.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.cloudwatch.region}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/controller/AwsController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/controller/AwsController.java
@@ -1,0 +1,19 @@
+package com.example.seoulpublicdata2025backend.domain.aws.controller;
+
+import com.example.seoulpublicdata2025backend.domain.aws.Service.AwsService;
+import com.example.seoulpublicdata2025backend.domain.aws.dto.PresignedUrlRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AwsController {
+    private final AwsService awsService;
+
+    @GetMapping("/files/presigned-url/put")
+    public String generatePutPresignedUrl(@ModelAttribute PresignedUrlRequestDto dto) {
+        return awsService.generatePutPreSignedUrl(dto);
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/controller/AwsController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/controller/AwsController.java
@@ -2,7 +2,9 @@ package com.example.seoulpublicdata2025backend.domain.aws.controller;
 
 import com.example.seoulpublicdata2025backend.domain.aws.Service.AwsService;
 import com.example.seoulpublicdata2025backend.domain.aws.dto.PresignedUrlRequestDto;
+import com.example.seoulpublicdata2025backend.domain.aws.dto.PresignedUrlResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,8 +14,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class AwsController {
     private final AwsService awsService;
 
-    @GetMapping("/files/presigned-url/put")
-    public String generatePutPresignedUrl(@ModelAttribute PresignedUrlRequestDto dto) {
-        return awsService.generatePutPreSignedUrl(dto);
+    @GetMapping("/files/presigned-url")
+    public ResponseEntity<PresignedUrlResponseDto> generatePutPresignedUrl(
+            @ModelAttribute PresignedUrlRequestDto dto
+    ) {
+        return ResponseEntity.ok(awsService.generatePutPreSignedUrl(dto));
     }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/dao/UploadFileRepository.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/dao/UploadFileRepository.java
@@ -1,0 +1,7 @@
+package com.example.seoulpublicdata2025backend.domain.aws.dao;
+
+import com.example.seoulpublicdata2025backend.domain.aws.entity.UploadFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UploadFileRepository extends JpaRepository<UploadFile, String> {
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/dto/PresignedUrlRequestDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/dto/PresignedUrlRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.seoulpublicdata2025backend.domain.aws.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PresignedUrlRequestDto {
+    private final String originalFileName;
+    private final Long kakaoId;
+    private final UploadType type;
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/dto/PresignedUrlResponseDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/dto/PresignedUrlResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.seoulpublicdata2025backend.domain.aws.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PresignedUrlResponseDto {
+    private final String presignedUrl;
+    private final String key;
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/dto/UploadType.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/dto/UploadType.java
@@ -1,0 +1,6 @@
+package com.example.seoulpublicdata2025backend.domain.aws.dto;
+
+public enum UploadType {
+    REVIEW,
+    ETC // 임시로 설정함
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/entity/UploadFile.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/aws/entity/UploadFile.java
@@ -1,0 +1,52 @@
+package com.example.seoulpublicdata2025backend.domain.aws.entity;
+
+import com.example.seoulpublicdata2025backend.domain.aws.dto.UploadType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "upload_files")
+public class UploadFile {
+    @Id
+    @Column(name = "upload_file_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long kakaoId;
+
+    @Column(nullable = false)
+    private String objectKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UploadType type; // REVIEW, ETC
+
+    @Column(nullable = false)
+    private String originalFileName;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UploadFile(Long kakaoId, String objectKey, UploadType type, String originalFileName) {
+        this.kakaoId = kakaoId;
+        this.objectKey = objectKey;
+        this.type = type;
+        this.originalFileName = originalFileName;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,8 @@ kakao.auth.redirect=http://localhost:8080/auth/login/kakao
 jwt.secret=${JWT_SECRET}
 jwt.expireDate.accessToken=7200000
 jwt.expireDate.refreshToken=2592000000
+
+spring.cloud.aws.cloudwatch.region=ap-northeast-2
+spring.cloud.aws.credentials.access-key=${AWS_ACCESS}
+spring.cloud.aws.credentials.secret-key=${AWS_SECRET}
+spring.cloud.aws.s3.bucket=${AWS_BUCKET}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #40 

## 📌 작업 내용 및 특이사항
- AWS S3 에 이미지를 업로드 할때 서버를 거치지 않고 바로 업로드가 가능하게 PreSigned Url 을 발급하는 기능입니다.
- 현재는 이미지를 업로드하는 연산만 가능합니다. (GET, PUT에 대한 PreSigned Url가 다름)
- 이미지 조회의 경우에는 저희가 PreSigned Url을 만들 때 사용한 key를 저장하고나서 클라이언트가 해당 키에 해당하는 이미지를 조회하고 싶다고 요청을 해야합니다. 

## 📝 참고사항
- 다음 3가지 환경변수를 추가해야 합니다.
1. AWS_ACCESS : IAM 계정의 access key
2. AWS_SECRET : IAM 계정의 secret key
3. AWS_BUCKET : S3 에서 사용하는 bucket 이름

## 📚 기타
-
