### PR TITLE
[Refactor] kakaoId를 쿠키로 이동, 만료시간은 2시간으로 수정

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.time.Duration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -48,17 +49,21 @@ public class KakaoAuthController {
 
         KakaoIdStatusDto kakaoIdStatusDto = memberService.initMember(kakaoId);
         String token = jwtProvider.createToken(kakaoIdStatusDto);
-        // JWT를 쿠키에 담기
-        ResponseCookie cookie = createCookie(token);
+
+        List<ResponseCookie> cookies = createCookies(token, kakaoId);
         String baseUrl = getBaseUrl(request);
-        HttpHeaders headers = setHttpHeaders(cookie, kakaoIdStatusDto, baseUrl, kakaoId);
+
+        HttpHeaders headers = setHttpHeaders(cookies, kakaoIdStatusDto, baseUrl, kakaoId);
         return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
 
-    private static HttpHeaders setHttpHeaders(ResponseCookie cookie, KakaoIdStatusDto kakaoIdStatusDto, String baseUrl,
-                                              Long kakaoId) {
+    private static HttpHeaders setHttpHeaders(
+            List<ResponseCookie> cookies, KakaoIdStatusDto kakaoIdStatusDto, String baseUrl, Long kakaoId
+    ) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.SET_COOKIE, cookie.toString());
+        for (ResponseCookie cookie : cookies) {
+            headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
+        }
         if (kakaoIdStatusDto.getStatus().equals(MemberStatus.MEMBER)) {
             String redirectUrl = UriComponentsBuilder.fromUriString(baseUrl)
                     .queryParam("kakaoId", kakaoId)
@@ -87,12 +92,22 @@ public class KakaoAuthController {
         return baseUrl;
     }
 
-    private static ResponseCookie createCookie(String token) {
-        return ResponseCookie.from("access", token)
+    private static List<ResponseCookie> createCookies(String token, Long kakaoId) {
+        ResponseCookie accessCookie = ResponseCookie.from("access", token)
                 .httpOnly(true)
                 .path("/")
                 .sameSite("Strict")
-                .maxAge(Duration.ofMinutes(30))
+                .maxAge(Duration.ofHours(2))
                 .build();
+
+        ResponseCookie kakaoIdCookie = ResponseCookie.from("kakaoId", kakaoId.toString())
+                .httpOnly(true)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(Duration.ofHours(2))
+                .build();
+
+        return List.of(accessCookie, kakaoIdCookie);
     }
+
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
@@ -53,12 +53,12 @@ public class KakaoAuthController {
         List<ResponseCookie> cookies = createCookies(token, kakaoId);
         String baseUrl = getBaseUrl(request);
 
-        HttpHeaders headers = setHttpHeaders(cookies, kakaoIdStatusDto, baseUrl, kakaoId);
+        HttpHeaders headers = setHttpHeaders(cookies, kakaoIdStatusDto, baseUrl);
         return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
 
     private static HttpHeaders setHttpHeaders(
-            List<ResponseCookie> cookies, KakaoIdStatusDto kakaoIdStatusDto, String baseUrl, Long kakaoId
+            List<ResponseCookie> cookies, KakaoIdStatusDto kakaoIdStatusDto, String baseUrl
     ) {
         HttpHeaders headers = new HttpHeaders();
         for (ResponseCookie cookie : cookies) {
@@ -66,13 +66,11 @@ public class KakaoAuthController {
         }
         if (kakaoIdStatusDto.getStatus().equals(MemberStatus.MEMBER)) {
             String redirectUrl = UriComponentsBuilder.fromUriString(baseUrl)
-                    .queryParam("kakaoId", kakaoId)
                     .build()
                     .toUriString();
             headers.setLocation(URI.create(redirectUrl));
         } else if (kakaoIdStatusDto.getStatus().equals(MemberStatus.PRE_MEMBER)) {
             String redirectUrl = UriComponentsBuilder.fromUriString(baseUrl + "/signup")
-                    .queryParam("kakaoId", kakaoId)
                     .build()
                     .toUriString();
             headers.setLocation(URI.create(redirectUrl));


### PR DESCRIPTION
## 🌱 관련 이슈
- close #49 

## 📌 작업 내용 및 특이사항
- 기존에 kakaoId를 쿼리 파라미터로 전송하는데, 쿠키로 이동하여 보안성을 높입니다.
- access token 만료시간을 2시간으로 설정했기에 쿠키도 2시간 동안 유효하게 했습니다. (refresh token이 없기 때문에 생명주기를 같게 하는게 맞다고 판단했습니다.)

## 📝 참고사항
-

## 📚 기타
-
