### PR TITLE
[Fix] Swagger 관련 url은 인증, 인가의 대상에서 제외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	implementation 'io.swagger.core.v3:swagger-annotations:2.2.30'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/SecurityConfig.java
@@ -25,6 +25,12 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> {
                     auth
+                            .requestMatchers("/auth/login/kakao",
+                                    "/v3/api-docs/**",
+                                    "/swagger-ui/**",
+                                    "/swagger-resources/**",
+                                    "/webjars/**")
+                                .permitAll()
                             .requestMatchers("/member/signup")
                                 .hasRole("PRE_MEMBER")
                             .anyRequest()


### PR DESCRIPTION
## 🌱 관련 이슈
- close #51

## 📌 작업 내용 및 특이사항
- 기존에는 필터링에서 제외할 URL을 단순히 문자열 비교를 했었는데, 그럼 와일드카드를 사용하지 못하는 예외가 있었습니다. 이를 `AntPathMatcher` 을 사용해서 해결하였습니다.

## 📝 참고사항
-

## 📚 기타
-
